### PR TITLE
Add -std=gnu99 to CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OBJS = \
 	dumpfont.o \
 	dumpgrx.o
 
-CFLAGS  = -Wall -I. -O2 #-O0 -g3 -DDEBUG
+CFLAGS  = -std=gnu99 -Wall -I. -O2 #-O0 -g3 -DDEBUG
 LDFLAGS = -L$(SCHRIFT)
 LIBS    = -lschrift -lm
 


### PR DESCRIPTION
Thanks for this tool, just need to adjust CFLAGS

Do you have any idea how the ".fnt" font files available in GRX and now MGRX were generated ?
I understand GRX and MGRX used fonts from the Linux Font Project, they must also have a conversion tool. But I couldn't find any information about it.